### PR TITLE
greengrass version bump to 1.9.1

### DIFF
--- a/roles/greengrass-core/defaults/main.yml
+++ b/roles/greengrass-core/defaults/main.yml
@@ -1,12 +1,12 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 or GPL-3.0-only
 ---
-greengrass_version: 1.6.0
+greengrass_version: 1.9.1
 
 # Define this to download from the web rather than S3
 #greengrass_package_url: "http://somewhere/greengrass-linux-x86-64-{{ greengrass_version }}.tar.gz"
 
-greengrass_checksum: sha256:e157c98967801d22935189f6394ed4a22dc9c9ca7bd521e601f21a3ec014d7eb
+greengrass_checksum: sha256:57ddc2727568a02e64f33b439d3bca563a7628b71790641d0e7354964103ea13
 
 root_ca_checksum: sha256:eec26a7b9d62e3f674bd7befede9c878d484707a85c0702a16f54cd0704544ed
 


### PR DESCRIPTION
New version of Greengrass has been released.

1.9.1 - Current version.
Fixes a bug introduced in v1.9.0 that drops messages from the cloud that contain wildcard characters in the topic.

1.9.0
New features:

Support for Python 3.7 and Node.js 8.10 Lambda runtimes. Lambda functions that use Python 3.7 and Node.js 8.10 runtimes can now run on an AWS IoT Greengrass core. (AWS IoT Greengrass continues to support the Python 2.7 and Node.js 6.10 runtimes.)

Optimized MQTT connections. The Greengrass core establishes fewer connections with the AWS IoT Core. This change can reduce operational costs for charges that are based on the number of connections.

Elliptic Curve (EC) key for the local MQTT server. The local MQTT server supports EC keys in addition to RSA keys. (The MQTT server certificate has an SHA-256 RSA signature, regardless of the key type.) For more information, see AWS IoT Greengrass Core Security Principals.

Bug fixes and improvements:

General performance improvements and bug fixes.

https://docs.aws.amazon.com/greengrass/latest/developerguide/what-is-gg.html#gg-core-download-tab