### PR TITLE
fix: missing greengrass_checksum and bump version

### DIFF
--- a/roles/greengrass-core/defaults/main.yml
+++ b/roles/greengrass-core/defaults/main.yml
@@ -1,7 +1,7 @@
 # Copyright © 2018 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0 or GPL-3.0-only
 ---
-greengrass_version: 1.9.1
+greengrass_version: 1.9.4
 
 # Define this to download from the web rather than S3
 #greengrass_package_url: "http://somewhere/greengrass-linux-x86-64-{{ greengrass_version }}.tar.gz"

--- a/roles/greengrass-core/tasks/greengrass-core.yml
+++ b/roles/greengrass-core/tasks/greengrass-core.yml
@@ -59,6 +59,7 @@
   get_url:
     url: "{{ greengrass_package_url }}"
     dest: /tmp/greengrass-linux-x86-64-{{ greengrass_version }}.tar.gz
+    checksum: "{{ greengrass_checksum }}"
   register: download_greengrass
   retries: 5
   delay: 5


### PR DESCRIPTION
Greeengrass checksum was defined in defaults but not used